### PR TITLE
Fixed cargo exclude paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,6 @@ description = "`svgc` (previously SvgCompress) is a tool for compressing SVG fil
 repository = "https://github.com/pasabanov/svgc"
 license = "AGPL-3.0-or-later"
 
-[package.metadata.i18n]
-available-locales = ["en", "ru"]
-default-locale = "en"
-load-path = "i18n"
-
 exclude = [
 	"/.github/",
 	"/.gitlab/",
@@ -28,6 +23,11 @@ exclude = [
 	"/.rustfmt.toml",
 	"/rustfmt.toml"
 ]
+
+[package.metadata.i18n]
+available-locales = ["en", "ru"]
+default-locale = "en"
+load-path = "i18n"
 
 [dependencies]
 chrono = "0.4.38"


### PR DESCRIPTION
**PR Type**  
- [x] Bug fix
- [x] Other: Cargo configuration

**Describe changes**  
Moved `exclude` list before `[package.metadata.i18n]` (to `[package]`).

**What is the current behavior?**  
The `exclude` list is applied to `[package.metadata.i18n]` instead of `[package]`, so it has no effect.

**What is the new behavior?**  
The specified paths should be excluded from the crate upon upload.

**How to test**  
This will be tested during the next version publishing.