### PR TITLE
Cargo.toml: Added .forgejo to exclude list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/pasabanov/svgc"
 license = "AGPL-3.0-or-later"
 
 exclude = [
+	"/.forgejo/",
 	"/.github/",
 	"/.gitlab/",
 	"/.idea/",


### PR DESCRIPTION
**PR Type**  
- [x] Other: Cargo configuration

**Describe changes**  
Added `.forgejo` to exclude list.

**What is the current behavior?**  
The `.forgejo` folder is not excluded from the Cargo crate.

**What is the new behavior?**  
The `.forgejo` folder will now be excluded from the Cargo crate.

**How to test**  
Publish to crates.io and verify that the `.forgejo` folder is not included.

**Other information**  
Forgejo is a free software package developed in Go for version control in software development with Git.