### PR TITLE
Disabled `posix` feature for `locale-match` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ directories = "5.0.1"
 dirs = "5.0.1"
 flate2 = "1.0.31"
 lazy_static = "1.5.0"
-locale-match = { version = "0.2.0", features = ["bcp47"] }
+locale-match = { version = "0.2.0", default-features = false, features = ["bcp47"] }
 regex = "1.10.6"
 rust-i18n = "3.1.2"
 sys-locale = "0.3.1"


### PR DESCRIPTION
**PR Type**  
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Localization / Internationalization
- [x] Chore (refactoring, formatting, cleanup, etc.)
- [ ] Other (please describe): _______

**Describe changes**  
Disabled the `posix` feature for the `locale-match` dependency by disabling the default features.