### PR TITLE
Added VS Code privacy and code style settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 !/.idea/runConfigurations/
 
 /.vscode/*
+!/.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,40 @@
+{
+	// Warning!
+	// Some of these settings only take effect if added to the user's `settings.json`
+	// and will not work in the workspace `settings.json`.
+	// It is recommended to copy the privacy-related settings into your user's `settings.json`.
+
+	// PRIVACY
+	// Telemetry
+	"telemetry.enableCrashReporter": false,
+	"telemetry.enableTelemetry": false,
+	"telemetry.telemetryLevel": "off",
+	"editor.experimental.treeSitterTelemetry": false,
+	"autotools.telemetry": false,
+	"dotnetAcquisitionExtension.enableTelemetry": false,
+	"julia.enableTelemetry": false,
+	"matlab.telemetry": false,
+	"redhat.telemetry.enabled": false,
+	// Experiments
+	"workbench.enableExperiments": false,
+	"jupyter.experiments.enabled": false,
+	"python.experiments.enabled": false,
+	// Other
+	"workbench.remoteIndicator.showExtensionRecommendations": false,
+	"workbench.settings.enableNaturalLanguageSearch": false,
+	"update.mode": "manual",
+	"update.showReleaseNotes": false,
+	"extensions.autoCheckUpdates": false,
+	"extensions.autoUpdate": false,
+	"extensions.ignoreRecommendations": true,
+	"yaml.extension.recommendations": false,
+
+	// CODE STYLE
+	// Indentation
+	"editor.detectIndentation": true,
+	"editor.indentSize": "tabSize",
+	"editor.insertSpaces": false,
+	// Final new line
+	"files.insertFinalNewline": false,
+	"files.trimFinalNewlines": true,
+}


### PR DESCRIPTION
**PR Type**  
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Localization / Internationalization
- [ ] Chore (refactoring, formatting, cleanup, etc.)
- [x] Other (please describe): VS Code configuration

**Describe changes**  
Added `.vscode/settings.json` file with the following configuration:
1. Privacy related settings:
	- Telemetry
	- Experiments
	- Other (recommendations, updates and a Microsoft online service)
2. Code style:
	- Indentation (tabs)
	- Final new line (no final new line)

Also added a warning message at the start of the file to suggest that developers copy the privacy-related settings to their user's `settings.json`, as some settings don't take effect in the workspace `settings.json`.