### PR TITLE
Renamed `fastcompile` profile to `fastbuild`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ lto = false
 debug = true
 strip = "none"
 
-[profile.fastcompile]
+[profile.fastbuild]
 inherits = "dev"
 # Compilation
 codegen-units = 8192


### PR DESCRIPTION
### Types of changes
- Configuration (build)

Related: 9b83ecc13d12bfd6f52b95ac1908fb1f14dce775

### Description
Renamed `fastcompile` profile to `fastbuild`.